### PR TITLE
Fix for vhost creation

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,10 +1,4 @@
 ---
-- name: collect vhosts
-  community.docker.docker_container_exec:
-    container: "{{ rabbitmq_container.name }}"
-    command: rabbitmqctl list_vhosts
-  register: list_vhosts
-
 - name: collect users
   community.docker.docker_container_exec:
     container: "{{ rabbitmq_container.name }}"
@@ -23,7 +17,6 @@
     container: "{{ rabbitmq_container.name }}"
     command: "rabbitmqctl add_vhost {{ item.vhost }}"
   loop: "{{ rabbitmq_users }}"
-  when: "item.vhost not in list_vhosts.stdout"
   ignore_errors: "{{ ansible_check_mode }}"
 
 - name: Create users


### PR DESCRIPTION
Since the data was not structured, for example a host named `galaxy` would never be created if a host named `galaxy-au` already existed.
Luckily `rabbitmqctl add_vhost` accepts vhosts that already exist, so this can quickly be fixed by removing the when condition. (And the idempotency)
