### PR TITLE
Disable potentially vulnerable TLS versions

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -31,6 +31,9 @@ rabbitmq_config:
     keyfile: /etc/ssl/user/privkey-rabbitmq.pem
     verify: verify_peer
     fail_if_no_peer_cert: 'false'
+    versions:
+      - tlsv1.3
+      - tlsv1.2
   management_agent:
     disable_metrics_collector: 'false'
   management:

--- a/templates/rabbitmq.conf.j2
+++ b/templates/rabbitmq.conf.j2
@@ -5,6 +5,9 @@ ssl_options.cacertfile = {{ rabbitmq_config.ssl_options.cacertfile }}
 ssl_options.certfile   = {{ rabbitmq_config.ssl_options.certfile }}
 ssl_options.keyfile    = {{ rabbitmq_config.ssl_options.keyfile }}
 ssl_options.verify     = {{ rabbitmq_config.ssl_options.verify}}
+{% for version in rabbitmq_config.ssl_options.versions %}
+ssl_options.versions.{{ loop.index }} = {{ version }}
+{% endfor %}
 ssl_options.fail_if_no_peer_cert = {{ rabbitmq_config.ssl_options.fail_if_no_peer_cert }}
 
 {% if rabbitmq_setup == "cluster" %}


### PR DESCRIPTION
My security guys chased me because of opened ssl/amqp (5671) port supporting TLS versions 1.0 and 1.1, considered to be vulnerable for weak ciphers.

This patch seems to fix it by allowing 1.2 and 1.3 only.