### PR TITLE
add rabbitmq_data_volume to defaults

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -54,8 +54,11 @@ rabbitmq_container:
 
 rabbitmq_container_pause: 20
 
+rabbitmq_data_volume: "{{ rabbitmq_path }}/data"
+
 rabbitmq_container_standalone_setup_details:
   volumes:
+    - "{{ rabbitmq_data_volume }}:/var/lib/rabbitmq"
     - "{{ rabbitmq_path }}/rabbitmq.conf:/etc/rabbitmq/rabbitmq.conf:ro"
     - "{{ rabbitmq_path }}/.erlang.cookie:/var/lib/rabbitmq/.erlang.cookie"
     - /etc/ssl:/etc/ssl:ro
@@ -66,6 +69,7 @@ rabbitmq_container_standalone_setup_details:
 
 rabbitmq_container_cluster_setup_details:
   volumes:
+    - "{{ rabbitmq_data_volume }}:/var/lib/rabbitmq"
     - "{{ rabbitmq_path }}/rabbitmq.conf:/etc/rabbitmq/rabbitmq.conf:ro"
     - "{{ rabbitmq_path }}/.erlang.cookie:/var/lib/rabbitmq/.erlang.cookie"
     - /etc/ssl:/etc/ssl:ro

--- a/tasks/init.yml
+++ b/tasks/init.yml
@@ -21,6 +21,12 @@
     state: directory
     mode: '0755'
 
+- name: Create the data directory for persistent volume
+  ansible.builtin.file:
+    path: "{{ rabbitmq_data_volume }}"
+    state: directory
+    mode: '0755'
+
 - name: Copy templates
   ansible.builtin.template:
     src: "{{ item.src }}"


### PR DESCRIPTION
Rabbitmq by default creates a volume for `/var/lib/rabbitmq`.

> This image makes all of /var/lib/rabbitmq a volume by default.


To stop this I added a mount point in volumes where one can define `rabbitmq_data_volume` when calling the role.

This could also be done with docker volumes but would require more work. We can keep this in mind for a future release.

usegalaxy-eu/issues#817